### PR TITLE
Add `compile` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ termcap.erl:
 clean:
 	[ -f termtypes.master ] && rm termtypes.master || true
 	[ -f termtypes.master.clean ] && rm termtypes.master.clean || true
-	
+
+compile:
+	rebar3 compile
+
 termtypes.master.clean: termtypes.master
 	cat termtypes.master | grep -v '^#' | grep -v '^\s*$$' > termtypes.master.clean
 


### PR DESCRIPTION
To make it usable with stock version of `erlang.mk`.

I'm trying to use `cf` from withing erlang.mk-based project, but it
fails to properly autopatch it. erlang.mk magic works properly when
Makefile contains some references to `rebar`.

Proper fix will be available within
https://github.com/ninenines/erlang.mk/issues/586

But currently it's far more easier to add single target to this project,
than to delve into shell script/make spaghetti :smile: 
